### PR TITLE
move tab index to the element with the styles

### DIFF
--- a/templates/partials/months.html
+++ b/templates/partials/months.html
@@ -10,7 +10,7 @@
 			{{#ifEquals weight 0}}
 			<div class="n-storylines__heatmap-segment-none"></div>
 			{{else}}
-			<div class="n-storylines__heatmap-segment-colour--background n-storylines__heatmap-segment--all" tabindex="0">
+			<div class="n-storylines__heatmap-segment-colour--background n-storylines__heatmap-segment--all" role="button" tabindex="0">
 				<div class="n-storylines__heatmap-segment-colour n-storylines__all-months" style="opacity: {{weight}};"></div>
 			</div>
 			<div class="n-storylines__summary">

--- a/templates/partials/months.html
+++ b/templates/partials/months.html
@@ -1,7 +1,7 @@
 <div class="n-storylines__scroll-container">
 	<div class="n-storylines__scroll-segments">
 		{{#each children}}
-		<div class="n-storylines__heatmap-segment" data-trackable="month-segment" tabindex="0">
+		<div class="n-storylines__heatmap-segment" data-trackable="month-segment">
 			<ul class="dot-container">
 				{{#if dot}} {{#each dot}}
 				<li class='dot' style="margin-left: {{position}}%">{{name}}</li>
@@ -10,7 +10,7 @@
 			{{#ifEquals weight 0}}
 			<div class="n-storylines__heatmap-segment-none"></div>
 			{{else}}
-			<div class="n-storylines__heatmap-segment-colour--background n-storylines__heatmap-segment--all">
+			<div class="n-storylines__heatmap-segment-colour--background n-storylines__heatmap-segment--all" tabindex="0">
 				<div class="n-storylines__heatmap-segment-colour n-storylines__all-months" style="opacity: {{weight}};"></div>
 			</div>
 			<div class="n-storylines__summary">

--- a/templates/partials/years.html
+++ b/templates/partials/years.html
@@ -1,13 +1,13 @@
 <div class="n-storylines__scroll-container">
 	<div class="n-storylines__scroll-segments">
 		{{#each children}}
-		<div class="n-storylines__heatmap-segment" data-trackable="year-segment" tabindex="0">
+		<div class="n-storylines__heatmap-segment" data-trackable="year-segment">
 			<ul class="dot-container">
 				{{#if dot}} {{#each dot}}
 				<li class='dot' style='margin-left: {{position}}%'>{{name}}</li>
 				{{/each}} {{/if}}
 			</ul>
-			<div class="n-storylines__heatmap-segment-colour--background n-storylines__heatmap-segment--all">
+			<div class="n-storylines__heatmap-segment-colour--background n-storylines__heatmap-segment--all" tabindex="0">
 				<div class="n-storylines__heatmap-segment-colour" style="opacity: {{weight}};"></div>
 			</div>
 			<div class="n-storylines__summary">

--- a/templates/partials/years.html
+++ b/templates/partials/years.html
@@ -7,7 +7,7 @@
 				<li class='dot' style='margin-left: {{position}}%'>{{name}}</li>
 				{{/each}} {{/if}}
 			</ul>
-			<div class="n-storylines__heatmap-segment-colour--background n-storylines__heatmap-segment--all" tabindex="0">
+			<div class="n-storylines__heatmap-segment-colour--background n-storylines__heatmap-segment--all" role="button" tabindex="0">
 				<div class="n-storylines__heatmap-segment-colour" style="opacity: {{weight}};"></div>
 			</div>
 			<div class="n-storylines__summary">


### PR DESCRIPTION
The element that has the hover (and now also focus) styles is `n-storylines__heatmap-segment--all`

<img width="598" alt="screen shot 2017-05-17 at 10 20 47" src="https://cloud.githubusercontent.com/assets/3425322/26147144/8a97f138-3aea-11e7-8948-e8d2926eff60.png">

but focus was going to its parent `n-storylines__heatmap-segment`, because that's where `tabindex=0` was.

This PR moves `tabindex=0` to `n-storylines__heatmap-segment--all`, so tabbing through each segment will give it that nice black border and show the tooltip, just like hovering

cc @TheoLeanse @gvonkoss 